### PR TITLE
Memory allocation

### DIFF
--- a/app.py
+++ b/app.py
@@ -18,7 +18,8 @@ args = [
     '--disable-setuid-sandbox',
     '--ignore-certificate-errors',
     '--disable-dev-shm-usage',
-    '--single-process'
+    '--single-process',
+    '--shm-size=3gb'
 ]
 
 loop = asyncio.get_event_loop()


### PR DESCRIPTION
give more access to allocated memory to prevent Protocol error Runtime.callFunctionOn: Target closed.